### PR TITLE
Fixing arn when updating

### DIFF
--- a/aws/data_access/data_access_to_target_accesspoint.go
+++ b/aws/data_access/data_access_to_target_accesspoint.go
@@ -172,6 +172,8 @@ func (a *AccessToTargetSyncer) handleAccessPoints(ctx context.Context) {
 		} else {
 			utils.Logger.Info(fmt.Sprintf("Updating access point %s", newName))
 
+			s3ApArn = existingAccessPoint.Arn
+
 			// Handle the who
 			err = a.repo.UpdateAccessPoint(ctx, newName, region, statements)
 			if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the correct access point identifier is set when updating existing access points, improving reliability of access point management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->